### PR TITLE
Fix string reference comparison

### DIFF
--- a/app/src/main/java/com/thetonyp/fixlollipopmemoryleak/FixLollipopMemoryLeak.java
+++ b/app/src/main/java/com/thetonyp/fixlollipopmemoryleak/FixLollipopMemoryLeak.java
@@ -26,7 +26,7 @@ public class FixLollipopMemoryLeak implements IXposedHookLoadPackage {
 
     @Override
     public void handleLoadPackage(LoadPackageParam lpparam) throws Throwable {
-        if ((lpparam.packageName != "android") || (lpparam.processName != "android"))
+        if (!lpparam.packageName.equals("android") || !lpparam.processName.equals("android"))
             return;
 
         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
The current implementation relies on the internal VM reference to
“android” be the same as the reference to the packageName and
processName objects. This particular if statement is not comparing the
actual value of the strings.

To reliably compare strings in Java with the equality operators every
non-statically internalized string must be suffixed with “.intern()”
Even that approach has some caveats.

I should add that I have not personally tested this change or the original code. I noticed the issue while browsing the source. It _could_ be working just fine as-is but that would be relying on the VM's behavior.
